### PR TITLE
Datum reader improvements

### DIFF
--- a/datum_reader.go
+++ b/datum_reader.go
@@ -270,7 +270,7 @@ func (this *SpecificDatumReader) mapEnum(field Schema, dec Decoder) (reflect.Val
 		return reflect.ValueOf(enumIndex), err
 	} else {
 		schema := field.(*EnumSchema)
-		fullName := schema.FullName()
+		fullName := GetFullName(schema)
 
 		if enumSymbolsToIndexCache[fullName] == nil {
 			enumSymbolsToIndexCacheLock.Lock()
@@ -472,7 +472,7 @@ func (this *GenericDatumReader) mapEnum(field Schema, dec Decoder) (*GenericEnum
 		return nil, err
 	} else {
 		schema := field.(*EnumSchema)
-		fullName := schema.FullName()
+		fullName := GetFullName(schema)
 
 		if enumSymbolsToIndexCache[fullName] == nil {
 			enumSymbolsToIndexCacheLock.Lock()

--- a/datum_reader.go
+++ b/datum_reader.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 )
 
 // Reader is an interface that may be implemented to avoid using runtime reflection during deserialization.
@@ -23,6 +24,9 @@ type DatumReader interface {
 	// Note that it must be called before calling Read.
 	SetSchema(Schema)
 }
+
+var enumSymbolsToIndexCache map[string]map[string]int32 = make(map[string]map[string]int32)
+var enumSymbolsToIndexCacheLock sync.Mutex
 
 // Generic Avro enum representation. This is still subject to change and may be rethought.
 type GenericEnum struct {
@@ -265,8 +269,26 @@ func (this *SpecificDatumReader) mapEnum(field Schema, dec Decoder) (reflect.Val
 	if enumIndex, err := dec.ReadEnum(); err != nil {
 		return reflect.ValueOf(enumIndex), err
 	} else {
-		enum := NewGenericEnum(field.(*EnumSchema).Symbols)
-		enum.SetIndex(enumIndex)
+		schema := field.(*EnumSchema)
+		fullName := schema.FullName()
+
+		if enumSymbolsToIndexCache[fullName] == nil {
+			enumSymbolsToIndexCacheLock.Lock()
+			if enumSymbolsToIndexCache[fullName] == nil {
+				symbolsToIndex := make(map[string]int32)
+				for index, symbol := range schema.Symbols {
+					symbolsToIndex[symbol] = int32(index)
+				}
+				enumSymbolsToIndexCache[fullName] = symbolsToIndex
+			}
+			enumSymbolsToIndexCacheLock.Unlock()
+		}
+
+		enum := &GenericEnum{
+			Symbols:        schema.Symbols,
+			symbolsToIndex: enumSymbolsToIndexCache[fullName],
+			index:          enumIndex,
+		}
 		return reflect.ValueOf(enum), nil
 	}
 }
@@ -449,8 +471,26 @@ func (this *GenericDatumReader) mapEnum(field Schema, dec Decoder) (*GenericEnum
 	if enumIndex, err := dec.ReadEnum(); err != nil {
 		return nil, err
 	} else {
-		enum := NewGenericEnum(field.(*EnumSchema).Symbols)
-		enum.SetIndex(enumIndex)
+		schema := field.(*EnumSchema)
+		fullName := schema.FullName()
+
+		if enumSymbolsToIndexCache[fullName] == nil {
+			enumSymbolsToIndexCacheLock.Lock()
+			if enumSymbolsToIndexCache[fullName] == nil {
+				symbolsToIndex := make(map[string]int32)
+				for index, symbol := range schema.Symbols {
+					symbolsToIndex[symbol] = int32(index)
+				}
+				enumSymbolsToIndexCache[fullName] = symbolsToIndex
+			}
+			enumSymbolsToIndexCacheLock.Unlock()
+		}
+
+		enum := &GenericEnum{
+			Symbols:        schema.Symbols,
+			symbolsToIndex: enumSymbolsToIndexCache[fullName],
+			index:          enumIndex,
+		}
 		return enum, nil
 	}
 }

--- a/datum_reader_test.go
+++ b/datum_reader_test.go
@@ -359,6 +359,7 @@ func specificReaderComplexVal() (Schema, []byte) {
 }
 
 func specificReaderBenchComplex(b *testing.B, dest interface{}) {
+	b.ReportAllocs()
 	schema, buf := specificReaderComplexVal()
 	datumReader := NewSpecificDatumReader()
 	datumReader.SetSchema(schema)

--- a/datum_utils.go
+++ b/datum_utils.go
@@ -16,7 +16,6 @@ limitations under the License. */
 package avro
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 )
@@ -33,7 +32,7 @@ func findField(where reflect.Value, name string) (reflect.Value, error) {
 	if rf, ok := rm.names[name]; ok {
 		return where.FieldByIndex(rf), nil
 	}
-	return reflect.Value{}, fmt.Errorf("Field %s does not exist in %s", name, t.Name())
+	return reflect.Value{}, FieldDoesNotExist
 }
 
 func reflectBuildRi(t reflect.Type) *reflectInfo {

--- a/errors.go
+++ b/errors.go
@@ -49,3 +49,6 @@ var InvalidSchema = errors.New("Invalid schema")
 
 // Happens when a datum reader has no set schema.
 var SchemaNotSet = errors.New("Schema not set")
+
+// FieldDoesNotExist happens when a struct does not have a necessary field.
+var FieldDoesNotExist = errors.New("Field does not exist")

--- a/schema.go
+++ b/schema.go
@@ -597,14 +597,6 @@ func (this *EnumSchema) GetName() string {
 	return this.Name
 }
 
-func (this *EnumSchema) FullName() string {
-	if this.Namespace == "" {
-		return this.GetName()
-	}
-
-	return fmt.Sprintf("%s.%s", this.Namespace, this.Name)
-}
-
 // Gets a custom non-reserved string property from this schema and a bool representing if it exists.
 func (this *EnumSchema) Prop(key string) (string, bool) {
 	if this.Properties != nil {
@@ -862,32 +854,29 @@ func (this *FixedSchema) MarshalJSON() ([]byte, error) {
 }
 
 func GetFullName(schema Schema) string {
-	switch schema.Type() {
-	case Record:
+	switch sch := schema.(type) {
+	case *RecordSchema:
 		{
-			recordSchema := schema.(*RecordSchema)
-			if recordSchema.Namespace == "" {
-				return recordSchema.GetName()
+			if sch.Namespace == "" {
+				return sch.GetName()
 			} else {
-				return fmt.Sprintf("%s.%s", recordSchema.Namespace, recordSchema.GetName())
+				return fmt.Sprintf("%s.%s", sch.Namespace, sch.GetName())
 			}
 		}
-	case Enum:
+	case *EnumSchema:
 		{
-			enumSchema := schema.(*EnumSchema)
-			if enumSchema.Namespace == "" {
-				return enumSchema.GetName()
+			if sch.Namespace == "" {
+				return sch.GetName()
 			} else {
-				return fmt.Sprintf("%s.%s", enumSchema.Namespace, enumSchema.GetName())
+				return fmt.Sprintf("%s.%s", sch.Namespace, sch.GetName())
 			}
 		}
-	case Fixed:
+	case *FixedSchema:
 		{
-			fixedSchema := schema.(*FixedSchema)
-			if fixedSchema.Namespace == "" {
-				return fixedSchema.GetName()
+			if sch.Namespace == "" {
+				return sch.GetName()
 			} else {
-				return fmt.Sprintf("%s.%s", fixedSchema.Namespace, fixedSchema.GetName())
+				return fmt.Sprintf("%s.%s", sch.Namespace, sch.GetName())
 			}
 		}
 	default:

--- a/schema.go
+++ b/schema.go
@@ -597,6 +597,14 @@ func (this *EnumSchema) GetName() string {
 	return this.Name
 }
 
+func (this *EnumSchema) FullName() string {
+	if this.Namespace == "" {
+		return this.GetName()
+	}
+
+	return fmt.Sprintf("%s.%s", this.Namespace, this.Name)
+}
+
 // Gets a custom non-reserved string property from this schema and a bool representing if it exists.
 func (this *EnumSchema) Prop(key string) (string, bool) {
 	if this.Properties != nil {


### PR DESCRIPTION
This PR improves performance of `findField` and `mapEnum`.

Benchmark results before changes (Core i5-3230M CPU @ 2.60GHz × 4):

```
BenchmarkSpecificDatumReader_complex-4	  300000	      4092 ns/op
BenchmarkSpecificDatumReader_hugeval-4	  300000	      4412 ns/op
BenchmarkEncodeVarint32-4             	30000000	        44.3 ns/op
BenchmarkEncodeVarint64-4             	30000000	        43.7 ns/op
BenchmarkSpecificDatumWriter-4        	  500000	      3932 ns/op
```

After:

```
BenchmarkSpecificDatumReader_complex-4	  500000	      3375 ns/op	     336 B/op	      12 allocs/op
BenchmarkSpecificDatumReader_hugeval-4	 2000000	       662 ns/op	      32 B/op	       1 allocs/op
BenchmarkEncodeVarint32-4             	30000000	        43.7 ns/op
BenchmarkEncodeVarint64-4             	30000000	        43.6 ns/op
BenchmarkSpecificDatumWriter-4        	  500000	      3715 ns/op
```

benchcmp results:

```
benchmark                                  old ns/op     new ns/op     delta       
BenchmarkSpecificDatumReader_complex-4     4092          3375          -17.52%     
BenchmarkSpecificDatumReader_hugeval-4     4412          662           -85.00%     
BenchmarkEncodeVarint32-4                  44.3          43.7          -1.35%      
BenchmarkEncodeVarint64-4                  43.7          43.6          -0.23%      
BenchmarkSpecificDatumWriter-4             3932          3715          -5.52%
```