### PR TITLE
Implement prepared schemas for faster decoding

### DIFF
--- a/datum_writer.go
+++ b/datum_writer.go
@@ -245,7 +245,7 @@ func (writer *SpecificDatumWriter) writeRecord(v reflect.Value, enc Encoder, s S
 		return fmt.Errorf("Invalid record value: %v", v.Interface())
 	}
 
-	rs := s.(*RecordSchema)
+	rs := assertRecordSchema(s)
 	for i := range rs.Fields {
 		schemaField := rs.Fields[i]
 		field, err := findField(v, schemaField.Name)
@@ -526,6 +526,8 @@ func (writer *GenericDatumWriter) isWritableAs(v interface{}, s Schema) bool {
 		panic("Nested unions not supported") //this is a part of spec: http://avro.apache.org/docs/current/spec.html#binary_encode_complex
 	case *RecordSchema:
 		_, ok = v.(*GenericRecord)
+	case *preparedRecordSchema:
+		_, ok = v.(*GenericRecord)
 	}
 
 	return ok
@@ -539,7 +541,7 @@ func (writer *GenericDatumWriter) writeRecord(v interface{}, enc Encoder, s Sche
 	switch value := v.(type) {
 	case *GenericRecord:
 		{
-			rs := s.(*RecordSchema)
+			rs := assertRecordSchema(s)
 			for i := range rs.Fields {
 				schemaField := rs.Fields[i]
 				field := value.Get(schemaField.Name)

--- a/datum_writer_test.go
+++ b/datum_writer_test.go
@@ -11,7 +11,16 @@ const primitiveSchemaRaw = `{"type":"record","name":"Primitive","namespace":"exa
 func TestSpecificDatumWriterPrimitives(t *testing.T) {
 	sch, err := ParseSchema(primitiveSchemaRaw)
 	assert(t, err, nil)
+	specificDatumWriterPrimitives(t, sch)
+}
 
+func TestSpecificDatumWriterPrimitives_prepared(t *testing.T) {
+	sch, err := ParseSchema(primitiveSchemaRaw)
+	assert(t, err, nil)
+	specificDatumWriterPrimitives(t, Prepare(sch))
+}
+
+func specificDatumWriterPrimitives(t *testing.T, sch Schema) {
 	buffer := &bytes.Buffer{}
 	enc := NewBinaryEncoder(buffer)
 
@@ -20,7 +29,7 @@ func TestSpecificDatumWriterPrimitives(t *testing.T) {
 
 	in := randomPrimitiveObject()
 
-	err = w.Write(in, enc)
+	err := w.Write(in, enc)
 	assert(t, err, nil)
 	dec := NewBinaryDecoder(buffer.Bytes())
 	r := NewSpecificDatumReader()

--- a/schema_prepared.go
+++ b/schema_prepared.go
@@ -1,0 +1,141 @@
+package avro
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+)
+
+/*
+Prepare optimizes a schema for decoding/encoding.
+
+It makes a recursive copy of the schema given and returns an immutable
+wrapper of the schema with some optimizations applied.
+*/
+func Prepare(schema Schema) Schema {
+	job := prepareJob{
+		seen: make(map[Schema]Schema),
+	}
+	return job.prepare(schema)
+}
+
+type prepareJob struct {
+	// the seen struct prevents infinite recursion by caching conversions.
+	seen map[Schema]Schema
+}
+
+func (job *prepareJob) prepare(schema Schema) Schema {
+	output := schema
+	switch schema := schema.(type) {
+	case *RecordSchema:
+		output = job.prepareRecordSchema(schema)
+	case *RecursiveSchema:
+		if seen := job.seen[schema.Actual]; seen != nil {
+			return seen
+		} else {
+			return job.prepare(schema.Actual)
+		}
+	case *UnionSchema:
+		output = job.prepareUnionSchema(schema)
+	case *ArraySchema:
+		output = job.prepareArraySchema(schema)
+	default:
+		return schema
+	}
+	job.seen[schema] = output
+	return output
+}
+
+func (job *prepareJob) prepareUnionSchema(input *UnionSchema) Schema {
+	output := &UnionSchema{
+		Types: make([]Schema, len(input.Types)),
+	}
+	for i, t := range input.Types {
+		output.Types[i] = job.prepare(t)
+	}
+	return output
+}
+
+func (job *prepareJob) prepareArraySchema(input *ArraySchema) Schema {
+	return &ArraySchema{
+		Properties: input.Properties,
+		Items:      job.prepare(input.Items),
+	}
+}
+func (job *prepareJob) prepareMapSchema(input *MapSchema) Schema {
+	return &MapSchema{
+		Properties: input.Properties,
+		Values:     job.prepare(input.Values),
+	}
+}
+
+func (job *prepareJob) prepareRecordSchema(input *RecordSchema) *preparedRecordSchema {
+	output := &preparedRecordSchema{
+		RecordSchema: *input,
+		pool:         sync.Pool{New: func() interface{} { return make(map[reflect.Type]*recordPlan) }},
+	}
+	output.Fields = nil
+	for _, field := range input.Fields {
+		output.Fields = append(output.Fields, &SchemaField{
+			Name:    field.Name,
+			Doc:     field.Doc,
+			Default: field.Default,
+			Type:    job.prepare(field.Type),
+		})
+	}
+	return output
+}
+
+type preparedRecordSchema struct {
+	RecordSchema
+	pool sync.Pool
+}
+
+func (rs *preparedRecordSchema) getPlan(t reflect.Type) (plan *recordPlan, err error) {
+	cache := rs.pool.Get().(map[reflect.Type]*recordPlan)
+	if plan = cache[t]; plan != nil {
+		rs.pool.Put(cache)
+		return
+	}
+
+	// Use the reflectmap to get field info.
+	ri := reflectEnsureRi(t)
+
+	decodePlan := make([]structFieldPlan, len(rs.Fields))
+	for i, schemafield := range rs.Fields {
+		index, ok := ri.names[schemafield.Name]
+		if !ok {
+			err = fmt.Errorf("Type %v does not have field %s required for decoding schema", t, schemafield.Name)
+		}
+		entry := &decodePlan[i]
+		entry.schema = schemafield.Type
+		entry.name = schemafield.Name
+		entry.index = index
+		entry.dec = specificDecoder(entry)
+	}
+
+	plan = &recordPlan{
+		// Over time, we will create decode/encode plans for more things.
+		decodePlan: decodePlan,
+	}
+	cache[t] = plan
+	rs.pool.Put(cache)
+	return
+}
+
+// This is used
+var sdr sDatumReader
+
+type recordPlan struct {
+	decodePlan []structFieldPlan
+}
+
+// For right now, until we implement more optimizations,
+// we have a lot of cases we want a *RecordSchema. This makes it a bit easier to deal with.
+func assertRecordSchema(s Schema) *RecordSchema {
+	rs, ok := s.(*RecordSchema)
+	if !ok {
+		rs = &s.(*preparedRecordSchema).RecordSchema
+	}
+	return rs
+}

--- a/schema_prepared_specific.go
+++ b/schema_prepared_specific.go
@@ -1,0 +1,53 @@
+package avro
+
+import "reflect"
+
+func specificDecoder(entry *structFieldPlan) preparedDecoder {
+	switch entry.schema.Type() {
+	case Record:
+		return recordDec(entry.schema)
+	case Enum:
+		return enumDec(entry.schema.(*EnumSchema))
+	default:
+		// Generic decoders get less drastic speedups, but we can add more later.
+		return genericDec(entry.schema)
+	}
+}
+
+// structFieldPlan is a plan that assists in decoding
+type structFieldPlan struct {
+	name   string
+	index  []int
+	schema Schema
+	dec    preparedDecoder
+}
+
+type preparedDecoder func(reflectField reflect.Value, dec Decoder) (reflect.Value, error)
+
+func genericDec(schema Schema) preparedDecoder {
+	return func(reflectField reflect.Value, dec Decoder) (reflect.Value, error) {
+		return sdr.readValue(schema, reflectField, dec)
+	}
+}
+
+func enumDec(schema *EnumSchema) preparedDecoder {
+	symbolsToIndex := NewGenericEnum(schema.Symbols).symbolsToIndex
+	return func(reflectField reflect.Value, dec Decoder) (reflect.Value, error) {
+		enumIndex, err := dec.ReadEnum()
+		if err != nil {
+			return reflect.ValueOf(enumIndex), err
+		}
+		enum := &GenericEnum{
+			Symbols:        schema.Symbols,
+			symbolsToIndex: symbolsToIndex,
+			index:          enumIndex,
+		}
+		return reflect.ValueOf(enum), nil
+	}
+}
+
+func recordDec(schema Schema) preparedDecoder {
+	return func(reflectField reflect.Value, dec Decoder) (reflect.Value, error) {
+		return sdr.mapRecord(schema, reflectField, dec)
+	}
+}


### PR DESCRIPTION
Preparing a schema returns an immutable schema so that we can
implement speedups conferred by knowing the value will not change.

Presently, only decoding speedups are implemented but this leaves
plenty of room for far more speedups in the future.

---

This is the first step of what I was talking about in [this comment](https://github.com/elodina/go-avro/issues/48#issuecomment-142037140)

Decoding speedups are primarily achieved by further memoizing the struct field lookup stuff (and enums, too) in a lock-free manner. The very first decode to a given struct type takes double the time because it's analyzing it, but repeated decoding yields noticeable speedups: 
33% on a single-threaded benchmark and an even more noticeable 40% on a multi-threaded bench. (x86-64, darwin)

```
single-thread:
BenchmarkSpecificDatumReader_complex            	  500000	      3008 ns/op	     304 B/op	      12 allocs/op
BenchmarkSpecificDatumReader_complex_prepared   	 1000000	      1989 ns/op	     304 B/op	      12 allocs/op
BenchmarkSpecificDatumReader_hugeval            	  500000	      3173 ns/op	     304 B/op	      12 allocs/op
BenchmarkSpecificDatumReader_hugeval_prepared   	 1000000	      2055 ns/op	     304 B/op	      12 allocs/op


parallel:

BenchmarkSpecificDatumReader_complex-4            	 1000000	      1807 ns/op	     304 B/op	      12 allocs/op
BenchmarkSpecificDatumReader_complex_prepared-4   	 1000000	      1067 ns/op	     304 B/op	      12 allocs/op
BenchmarkSpecificDatumReader_hugeval-4            	 1000000	      1710 ns/op	     304 B/op	      12 allocs/op
BenchmarkSpecificDatumReader_hugeval_prepared-4   	 1000000	      1092 ns/op	     304 B/op	      12 allocs/op
```