### PR TITLE
A fix to the GenericRecord::Map() method that gets called while doing a

### DIFF
--- a/generic_record.go
+++ b/generic_record.go
@@ -68,7 +68,7 @@ func (gr *GenericRecord) Map() map[string]interface{} {
 	m := make(map[string]interface{})
 	for k, v := range gr.fields {
 		if r, ok := v.(*GenericRecord); ok {
-			v = (r)
+			v = r.Map()
 		}
 		if a, ok := v.([]interface{}); ok {
 			slice := make([]interface{}, len(a))


### PR DESCRIPTION
Read on a nested Record structure [Record containing another Record]