### PR TITLE
Support absolute name type references.

### DIFF
--- a/schema_test.go
+++ b/schema_test.go
@@ -260,13 +260,21 @@ func TestFixedSchema(t *testing.T) {
 }
 
 func TestSchemaRegistryMap(t *testing.T) {
-	rawSchema1 := `{"type": "record", "name": "TestRecord", "fields": [
-     	{"name": "longRecordField", "type": "long"}
-     ]}`
+	rawSchema1 := `{"type": "record", "name": "TestRecord", "namespace": "com.github.elodina", "fields": [
+		{"name": "longRecordField", "type": "long"}
+	]}`
 
-	rawSchema2 := `{"type": "record", "name": "TestRecord2", "fields": [
-     	{"name": "record", "type": ["null", "TestRecord"]}
-     ]}`
+	rawSchema2 := `{"type": "record", "name": "TestRecord2", "namespace": "com.github.elodina", "fields": [
+		{"name": "record", "type": ["null", "TestRecord"]}
+	]}`
+
+	rawSchema3 := `{"type": "record", "name": "TestRecord3", "namespace": "com.github.other", "fields": [
+		{"name": "record", "type": ["null", "com.github.elodina.TestRecord2"]}
+	]}`
+
+	rawSchema4 := `{"type": "record", "name": "TestRecord3", "namespace": "com.github.elodina", "fields": [
+		{"name": "record", "type": ["null", {"type": "TestRecord2"}, "com.github.other.TestRecord3"]}
+	]}`
 
 	registry := make(map[string]Schema)
 
@@ -279,6 +287,16 @@ func TestSchemaRegistryMap(t *testing.T) {
 	assert(t, err, nil)
 	assert(t, s2.Type(), Record)
 	assert(t, len(registry), 2)
+
+	s3, err := ParseSchemaWithRegistry(rawSchema3, registry)
+	assert(t, err, nil)
+	assert(t, s3.Type(), Record)
+	assert(t, len(registry), 3)
+
+	s4, err := ParseSchemaWithRegistry(rawSchema4, registry)
+	assert(t, err, nil)
+	assert(t, s4.Type(), Record)
+	assert(t, len(registry), 4)
 }
 
 func TestRecordCustomProps(t *testing.T) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -12,6 +12,7 @@ func assert(t *testing.T, actual interface{}, expected interface{}) {
 	if !reflect.DeepEqual(actual, expected) {
 		_, fn, line, _ := runtime.Caller(1)
 		t.Errorf("Expected %v, actual %v\n@%s:%d", expected, actual, fn, line)
+		t.FailNow()
 	}
 }
 


### PR DESCRIPTION
When we have schemas that reference schemas in a different
packages, you use the full dotted path name to reference the type.

Support these paths during schema import.

Also, as an addition, support the alternate syntax for specifying a type `{"type": "CustomType"}` just for completeness.