### PR TITLE
Encoding speedups for strings and bools

### DIFF
--- a/binary_serialization_test.go
+++ b/binary_serialization_test.go
@@ -39,6 +39,16 @@ func TestBooleanSerialization(t *testing.T) {
 	}
 }
 
+func BenchmarkBooleanSerialization(b *testing.B) {
+	buf := &bytes.Buffer{}
+	enc := NewBinaryEncoder(buf)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		enc.WriteBoolean(true)
+		buf.Reset()
+	}
+}
+
 func TestIntSerialization(t *testing.T) {
 	testPrimitiveSerialization(t, func(i int) interface{} {
 		r := rand.Int31() / (int32(i) * int32(i))
@@ -118,6 +128,34 @@ func TestStringSerialization(t *testing.T) {
 		NewBinaryEncoder(buf).WriteString(r.(string))
 		return NewBinaryDecoder(buf.Bytes()).ReadString()
 	})
+}
+
+func BenchmarkStringSerialization_small(b *testing.B) {
+	benchStringSerialization(b, 10)
+}
+
+func BenchmarkStringSerialization_med(b *testing.B) {
+	benchStringSerialization(b, 70)
+}
+
+func BenchmarkStringSerialization_large(b *testing.B) {
+	benchStringSerialization(b, 2000)
+}
+
+func benchStringSerialization(b *testing.B, n int) {
+	s := "abcdefghijklmnop"
+	for len(s) < n {
+		s += s
+	}
+	s = s[:n]
+
+	buf := &bytes.Buffer{}
+	enc := NewBinaryEncoder(buf)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		enc.WriteString(s)
+		buf.Reset()
+	}
 }
 
 func testPrimitiveSerialization(t *testing.T, random func(int) interface{}, serialize func(interface{}) (interface{}, error)) {

--- a/encoder.go
+++ b/encoder.go
@@ -68,12 +68,16 @@ func (be *BinaryEncoder) WriteNull(_ interface{}) {
 	//do nothing
 }
 
+// The encodings of true and false, for reuse
+var encBoolTrue = []byte{0x01}
+var encBoolFalse = []byte{0x00}
+
 // WriteBoolean writes a boolean value.
 func (be *BinaryEncoder) WriteBoolean(x bool) {
 	if x {
-		_, _ = be.buffer.Write([]byte{0x01})
+		_, _ = be.buffer.Write(encBoolTrue)
 	} else {
-		_, _ = be.buffer.Write([]byte{0x00})
+		_, _ = be.buffer.Write(encBoolFalse)
 	}
 }
 
@@ -115,7 +119,8 @@ func (be *BinaryEncoder) WriteBytes(x []byte) {
 // WriteString writes a string value.
 func (be *BinaryEncoder) WriteString(x string) {
 	be.WriteLong(int64(len(x)))
-	_, _ = be.buffer.Write([]byte(x))
+	// call writers that happen to provide WriteString to avoid extra byte allocations for a copy of a string when possible.
+	_, _ = io.WriteString(be.buffer, x)
 }
 
 // WriteArrayStart should be called when starting to serialize an array providing it with a number of items in


### PR DESCRIPTION
Some speedups on string and boolean encoding primarily by reducing the amount of allocations required, thus reducing gc garbage as well.  The string encoding speedup was pretty significant, because it saves an extra copy of the whole string, so the longer the string the better the speedup, but even on short strings you get 21.66% speedup.

String results:

```
$ benchcmp a.txt b.txt 
benchmark                              old ns/op     new ns/op     delta
BenchmarkStringSerialization_small     157           123           -21.66%
BenchmarkStringSerialization_med       181           126           -30.39%
BenchmarkStringSerialization_large     730           186           -74.52%
```

Boolean results:

```
$ benchcmp a.txt b.txt 
benchmark                           old ns/op     new ns/op     delta
BenchmarkBooleanSerialization-4     36.3          21.8          -39.94%
```
