### PR TITLE
Add enumSchema validate

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -632,9 +632,17 @@ func (s *EnumSchema) Prop(key string) (interface{}, bool) {
 }
 
 // Validate checks whether the given value is writeable to this schema.
-func (*EnumSchema) Validate(v reflect.Value) bool {
-	//TODO implement
-	return true
+func (s *EnumSchema) Validate(v reflect.Value) bool {
+	v = dereference(v)
+	if v.Kind() != reflect.Struct {
+		return false
+	}
+	field := v.FieldByName("index")
+	if !field.IsValid() {
+		return false
+	}
+	val := field.Interface().(int)
+	return val >= 0 && val < len(s.Symbols)
 }
 
 // MarshalJSON serializes the given schema as JSON.

--- a/schema.go
+++ b/schema.go
@@ -637,11 +637,15 @@ func (s *EnumSchema) Validate(v reflect.Value) bool {
 	if v.Kind() != reflect.Struct {
 		return false
 	}
-	field := v.FieldByName("index")
-	if !field.IsValid() {
+	method := v.MethodByName("getindex")
+	if !method.IsValid() {
 		return false
 	}
-	val := field.Interface().(int)
+	valArr := method.Call([]reflect.Value{})
+	if len(valArr) == 0 {
+		return false
+	}
+	val := valArr[0].Interface().(int)
 	return val >= 0 && val < len(s.Symbols)
 }
 


### PR DESCRIPTION
After looking and debug around in our project, I found you guys left TODO for EnumSchema validate function and return TRUE T_T
This TRUE produces a lot of panic in our service.
So I finish the validate function for our own production env.
I did the follow thins:
1. check if it is a struct
2. check if it contains index field
3. check if the field is in range(0<=index<len(enumSchema.Symbols))
